### PR TITLE
Remove type hints from functions

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from pipeline import haversine_km
 
 
-def build_item_coordinates(proc: dict) -> dict:
+def build_item_coordinates(proc):
     """Collect item coordinates from rich review units."""
     coords = defaultdict(dict)
     for unit in proc.get('RICH_REVIEWS', []):
@@ -18,7 +18,7 @@ def build_item_coordinates(proc: dict) -> dict:
     return coords
 
 
-def compute_utility(proc: dict, query=None) -> dict:
+def compute_utility(proc, query=None):
     """Compute utility scores for each user-item pair given PROC artifacts."""
     user_geo = proc.get('USER_GEO', {})
     item_perf = proc.get('ITEM_ASPECT_PERF', {})
@@ -47,7 +47,7 @@ def compute_utility(proc: dict, query=None) -> dict:
     return utilities
 
 
-def apps_run(args, proc: dict) -> dict:
+def apps_run(args, proc):
     """Example STEP-3 runner returning utility grids."""
     utilities = compute_utility(proc)
     summary = {

--- a/bin/playground/embedding_symmetry.py
+++ b/bin/playground/embedding_symmetry.py
@@ -30,7 +30,7 @@ def embed_texts(texts, model_name, batch_size, normalize=True):
     return embs.cpu().numpy().astype("float32")
 
 
-def main(cfg: Config = Config()):
+def main(cfg=Config()):
     # --- Define comments ---
     comments = {
         "good_fry": [

--- a/bin/playground/reproducibility.py
+++ b/bin/playground/reproducibility.py
@@ -16,7 +16,7 @@ class Config:
 
 # -------------- Experiment --------------
 
-def run_reproducibility_experiment(embedder, info_by_id, cfg: Config = Config()):
+def run_reproducibility_experiment(embedder, info_by_id, cfg=Config()):
     vecs, index, chunk_infos = (
         embedder.vecs,
         embedder.index,

--- a/bin/vectorize_yelp.py
+++ b/bin/vectorize_yelp.py
@@ -130,7 +130,7 @@ def build_index(vecs, index_type = 'flatip'):
 
 import re
 
-def _smart_wrap_sentence(s: str, max_chars: int):
+def _smart_wrap_sentence(s, max_chars):
     """
     Split a single (possibly very long) sentence into chunks <= max_chars.
     Prefer strong punctuation, then weak punctuation/space, else hard cut.

--- a/helper/continuity_check.py
+++ b/helper/continuity_check.py
@@ -20,7 +20,7 @@ def review_id(review):
     return None
 
 
-def normalize_for_fuzzy(s: str) -> str:
+def normalize_for_fuzzy(s):
     """
     Lightweight normalization for fuzzy matching:
       - Unicode NFKC
@@ -33,7 +33,7 @@ def normalize_for_fuzzy(s: str) -> str:
     return s.strip()
 
 
-def fuzzy_contains(text: str, excerpt: str, rel=FUZZY_MAX_REL_ERR, abs_err=FUZZY_MAX_ABS_ERR):
+def fuzzy_contains(text, excerpt, rel=FUZZY_MAX_REL_ERR, abs_err=FUZZY_MAX_ABS_ERR):
     """
     Damerau-Levenshtein (optimal string alignment) approximate *substring* match.
     Returns (start_norm, end_norm, distance) over the *normalized* text if within threshold,

--- a/llm.py
+++ b/llm.py
@@ -46,7 +46,7 @@ PRICING_PER_TOKEN = {
     "gpt-4-turbo":  {"in": 10.00/1_000_000,"out": 30.00/1_000_000},
 }
 
-def _resolve_rates(model: str):
+def _resolve_rates(model):
     m = model.lower()
     if m in PRICING_PER_TOKEN:
         return PRICING_PER_TOKEN[m]
@@ -56,7 +56,7 @@ def _resolve_rates(model: str):
             return PRICING_PER_TOKEN[k]
     return None
 
-def _estimate_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> float:
+def _estimate_cost_usd(model, prompt_tokens, completion_tokens):
     rates = _resolve_rates(model)
     if not rates:
         return 0.0

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from utils import load_or_build, readf, dumpj, loadj
 from pipeline import prepare_basic, process_build
 
 
-def main() -> None:
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--dset', default='yelp')
     parser.add_argument('--cache_dir', default='cache')

--- a/past/dataset/build_features.py
+++ b/past/dataset/build_features.py
@@ -26,13 +26,13 @@ ppause = partial(pause_if, flag=PAUSE)
 
 embed_model = SentenceTransformer("BAAI/bge-small-en-v1.5")
 
-def embed(text: str) -> np.ndarray:
+def embed(text):
     return embed_model.encode(text, normalize_embeddings=True)
 
 def cosine(a, b):
     return float(csim(a.reshape(1, -1), b.reshape(1, -1))[0][0])
 
-def clean_phrase(phrase: str) -> str:
+def clean_phrase(phrase):
     return phrase.lower().strip("* ").split(". ")[-1].strip()
 
 ### --- Ontology Node and Ontology Structure --- ###
@@ -52,7 +52,7 @@ class OntologyNode:
             if type_ == "USER": self.user2score[id] = {'scores': [], 'avg': -100}
             if type_ == "ITEM": self.item2score[id] = {'scores': [], 'avg': -100}
 
-    def update(self, alias: str):
+    def update(self, alias):
         self.aliases.add(alias)
 
     def __repr__(self):
@@ -101,7 +101,7 @@ class Ontology:
         else:
             vlog("add_or_update_node: unkown type")
 
-    def add_or_update_node(self, review_id, type_, id, phrase, description, score) -> bool:
+    def add_or_update_node(self, review_id, type_, id, phrase, description, score):
         """
         回傳 True = 新增了一個 node (包括 CHILD / PARENT 分支)，
         False = 只是加了 alias 或回傳到既有 node。
@@ -185,7 +185,7 @@ Decide the best relationship for the new feature and follow the output format:
             for iid in node.item2score:
                 if node.item2score[iid]['scores']: node.item2score[iid]['avg'] = statistics.mean(node.item2score[iid]['scores'])
 
-    def save_json(self, path: Path):
+    def save_json(self, path):
         json_dict = {
             name: {
                 "name": n.name,
@@ -200,7 +200,7 @@ Decide the best relationship for the new feature and follow the output format:
         with open(path, "w") as f:
             json.dump(json_dict, f, indent=2)
     
-    def save_txt(self, path: Path):
+    def save_txt(self, path):
         json_dict = {
             name: {
                 "name": n.name,
@@ -223,7 +223,7 @@ Decide the best relationship for the new feature and follow the output format:
 
         lines = []
 
-        def dfs(node_id: str, depth: int, stack: set):
+        def dfs(node_id, depth, stack):
             if node_id in stack:
                 lines.append("\t"*depth + f"{json_dict[node_id].get('name', node_id)} (cycle detected)")
                 return
@@ -241,7 +241,7 @@ Decide the best relationship for the new feature and follow the output format:
 
         Path(path).write_text("\n".join(lines), encoding="utf-8")
 
-    def read_txt(self, path: Path) -> bool:
+    def read_txt(self, path):
         try:
             text = Path(path).read_text(encoding="utf-8")
         except Exception as e:
@@ -252,7 +252,7 @@ Decide the best relationship for the new feature and follow the output format:
         parsed = []
         line_no = 0
 
-        def split_remove_flag(name: str) -> Tuple[str, bool]:
+        def split_remove_flag(name):
             s = name.strip()
             low = s.lower()
             if low.endswith("(remove)"):
@@ -393,7 +393,7 @@ Decide the best relationship for the new feature and follow the output format:
 
         return True
 
-def extract_feature_mentions(text: str, ontology: Ontology = None, dset = None, model="openai") -> List[Tuple[str, str, float]]:
+def extract_feature_mentions(text, ontology=None, dset=None, model="openai"):
     hint_str = ', '.join(ontology.feature_hints(text)) if ontology else []
 
     if dset == 'yelp':
@@ -441,7 +441,7 @@ feature name | definition | score (float between -1.0 and 1.0)
                 continue
     return results
 
-def human_in_the_loop_update(new_since_refine: int, new_features: List[str], ontology: Ontology = None) -> None:
+def human_in_the_loop_update(new_since_refine, new_features, ontology=None):
     ontology.save_txt(Path("cache/ontology_human_in_the_loop.txt"))
     print(f"\n>>> 已新增 {new_since_refine} 個新 feature：{new_features}\n>>> 請打開 Ontology 進行微調，完成後按 Enter 繼續...")
     input()
@@ -452,7 +452,7 @@ def human_in_the_loop_update(new_since_refine: int, new_features: List[str], ont
         valid = ontology.read_txt(Path("cache/ontology_human_in_the_loop.txt"))
 
 ### --- Main Ontology Building Function --- ###
-def build_ontology_by_reviews(args, review_type_id_pairs: List[Tuple[Dict, str, str]], K: int = 10) -> Ontology:
+def build_ontology_by_reviews(args, review_type_id_pairs, K=10):
     review_cnt = len(review_type_id_pairs)
 
     node_cnt = []

--- a/past/dataset/build_profiles.py
+++ b/past/dataset/build_profiles.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from pathlib import Path
 from utils import loadj, dumpj
 
-def load_data(data_dir: Path):
+def load_data(data_dir):
     """Load all required JSON files"""
     print("Loading data...")
     yelp_data = loadj(data_dir / "yelp_data.json")

--- a/past/dataset/ontology_old.py
+++ b/past/dataset/ontology_old.py
@@ -26,13 +26,13 @@ ppause = partial(pause_if, flag=PAUSE)
 
 embed_model = SentenceTransformer("BAAI/bge-small-en")
 
-def embed(text: str) -> np.ndarray:
+def embed(text):
     return embed_model.encode(text, normalize_embeddings=True)
 
 def cosine(a, b):
     return float(csim(a.reshape(1, -1), b.reshape(1, -1))[0][0])
 
-def clean_phrase(phrase: str) -> str:
+def clean_phrase(phrase):
     return phrase.lower().strip("* ").split(". ")[-1].strip().replace("*", "").strip().replace(" ", "_")
 
 ### --- Ontology Node and Ontology Structure --- ###
@@ -47,7 +47,7 @@ class OntologyNode:
         self.children = {}
         self.parent = None
 
-    def update(self, alias: str):
+    def update(self, alias):
         self.aliases.add(alias)
 
     def __repr__(self):
@@ -84,7 +84,7 @@ class Ontology:
         scored.sort(reverse=True, key=lambda x: x[0])
         return [node for node in scored[:top_k]]
 
-    def get_node_depth(self, node: OntologyNode) -> int:
+    def get_node_depth(self, node):
         depth = 0
         current = node 
         while current.parent is not None:
@@ -93,9 +93,9 @@ class Ontology:
             current = current.parent
         return depth
     
-    def root_max_depth(self, root: OntologyNode) -> int:
+    def root_max_depth(self, root):
         """回傳以 root 為根的子樹，其所有節點(以整棵樹根為基準)深度的最大值。"""
-        def dfs(n: OntologyNode) -> int:
+        def dfs(n):
             cur = self.get_node_depth(n)
             if not n.children:
                 return cur
@@ -107,7 +107,7 @@ class Ontology:
             node = node.parent
         return node
 
-    def added_as_root(self, new_id: str, review_id: str, score: float, description: str) -> bool:
+    def added_as_root(self, new_id, review_id, score, description):
         """
         新增一個全新的 ROOT node。
         """
@@ -120,7 +120,7 @@ class Ontology:
         self.review2node_id_score[review_id].append((new_id, score))
         vlog(f"'{new_id}' added as ROOT node")
 
-    def added_as_alias(self, target: str, alias: str, review_id: str, score: float) -> bool:
+    def added_as_alias(self, target, alias, review_id, score):
         """
         將一個 alias 加入到已存在的 node 中。
         """
@@ -131,7 +131,7 @@ class Ontology:
         vlog(f"'{alias}' added as ALIAS to '{target}'")
         return False
 
-    def added_as_child(self, parent: str, new_id: str, review_id: str, score: float, description: str) -> bool:
+    def added_as_child(self, parent, new_id, review_id, score, description):
         """
         將 new_id 設為 parent node 的 child。
         """
@@ -155,7 +155,7 @@ class Ontology:
         vlog(f"'{new_id}' added as CHILD to '{parent}'")
         return True
 
-    def added_as_parent(self, new_id: str, child: str, review_id: str, score: float, description: str) -> bool:
+    def added_as_parent(self, new_id, child, review_id, score, description):
         """
         將 new_id 設為 child node 的 parent。
         """
@@ -179,7 +179,7 @@ class Ontology:
         vlog(f"'{new_id}' added as PARENT to '{child}'")
         return True
 
-    def add_or_update_node(self, review_id, phrase, description, score) -> bool:
+    def add_or_update_node(self, review_id, phrase, description, score):
         """
         回傳 True = 新增了一個 node (包括 CHILD / PARENT 分支)，
         False = 只是加了 alias 或回傳到既有 node。
@@ -232,7 +232,7 @@ Only return the decision, no explanations or extra text.
         #self.review2node_id_score[review_id].append((node_id, score))
         #return True
 
-    def save_json(self, path: Path):
+    def save_json(self, path):
         json_dict = {
             name: {
                 "name": n.name,
@@ -245,7 +245,7 @@ Only return the decision, no explanations or extra text.
         with open(path, "w") as f:
             json.dump(json_dict, f, indent=2)
     
-    def save_txt(self, path: Path, new_features: List[str] = None):
+    def save_txt(self, path, new_features=None):
         json_dict = {
             name: {
                 "name": n.name,
@@ -268,20 +268,20 @@ Only return the decision, no explanations or extra text.
 
         lines = []
 
-        def get_all_children(node_id: str) -> list:
+        def get_all_children(node_id):
             """取得某個節點的所有子節點名稱"""
             if node_id not in json_dict:
                 return []
             return json_dict[node_id].get("children", [])
 
-        def add_node_to_lines(node_id: str):
+        def add_node_to_lines(node_id):
             """將節點加入輸出列表，處理新特徵標記"""
             node_name = json_dict[node_id]["name"]
             if new_features and node_name in new_features:
                 return f"{node_name}*"
             return node_name
 
-        def dfs(node_id: str, depth: int, visited: set):
+        def dfs(node_id, depth, visited):
             if node_id in visited:
                 lines.append("\t"*depth + f"{json_dict[node_id]['name']} (cycle detected)")
                 return
@@ -315,7 +315,7 @@ Only return the decision, no explanations or extra text.
 
         Path(path).write_text("\n".join(lines), encoding="utf-8")
 
-    def read_txt(self, path: Path) -> bool:
+    def read_txt(self, path):
         try:
             text = Path(path).read_text(encoding="utf-8")
         except Exception as e:
@@ -326,7 +326,7 @@ Only return the decision, no explanations or extra text.
         parsed = []
         line_no = 0
 
-        def split_flags(name: str) -> Tuple[str, bool, Optional[str]]:
+        def split_flags(name):
             s = name.strip()
             low = s.lower()
             # remove
@@ -516,7 +516,7 @@ Only return the decision, no explanations or extra text.
             node.parent = None
             node.children.clear()
 
-        def _m(name: Optional[str]) -> Optional[str]:
+        def _m(name):
             if name is None:
                 return None
             return rename_map.get(name, name)
@@ -547,7 +547,7 @@ Only return the decision, no explanations or extra text.
 
         return True
 
-def extract_feature_mentions(text: str, ontology: Ontology = None, dset = None, model="openai") -> List[Tuple[str, float]]:
+def extract_feature_mentions(text, ontology=None, dset=None, model="openai"):
     hint_str = ', '.join(ontology.feature_hints(text)) if ontology else []
 
     if dset == 'yelp':
@@ -595,7 +595,7 @@ feature name | definition | score (float between -1.0 and 1.0)
                 continue
     return results
 
-def human_in_the_loop_update(new_since_refine: int, new_features: List[str], update_cnt: int, ontology: Ontology = None) -> None:
+def human_in_the_loop_update(new_since_refine, new_features, update_cnt, ontology=None):
     ontology.save_txt(Path(f"cache/ontology_human_in_the_loop_{update_cnt}.txt"), new_features)
     print(f"\n>>> 已新增 {new_since_refine} 個新 feature：{new_features}\n>>> 請打開 Ontology {update_cnt} 進行微調（標記 * 為新增 feature），完成後按 Enter 繼續...")
     input()
@@ -606,7 +606,7 @@ def human_in_the_loop_update(new_since_refine: int, new_features: List[str], upd
         valid = ontology.read_txt(Path(f"cache/ontology_human_in_the_loop_{update_cnt}.txt"))
 
 ### --- Main Ontology Building Function --- ###
-def build_ontology_by_reviews(args, reviews: List[Dict], K: int = 10) -> Ontology:
+def build_ontology_by_reviews(args, reviews, K=10):
     review_cnt = len(reviews)
 
     node_cnt = []

--- a/past/test_ontology.py
+++ b/past/test_ontology.py
@@ -2,7 +2,7 @@ from dataset.ontology import Ontology, OntologyNode, clean_phrase
 from pathlib import Path
 import pytest
 
-def _write_lines(path: Path, lines):
+def _write_lines(path, lines):
     with open(path, "w", encoding="utf-8") as f:
         for ln in lines:
             f.write(ln + "\n")
@@ -149,7 +149,7 @@ def test_remove_functionality():
 
 
 
-def _build_base_tree(o: Ontology):
+def _build_base_tree(o):
     """
     建立基礎節點並寫入一份「合法層級」TXT（深度<=3）：
     service quality

--- a/pipeline.py
+++ b/pipeline.py
@@ -11,13 +11,13 @@ import numpy as np
 _GLOBAL_RNG = np.random.default_rng(42)
 
 
-def set_random_seed(seed: int | None) -> None:
+def set_random_seed(seed):
     """Seed the shared RNG used across PROCESS helpers."""
     global _GLOBAL_RNG
     _GLOBAL_RNG = np.random.default_rng(int(seed) if seed is not None else 42)
 
 
-def prepare_basic(args) -> dict:
+def prepare_basic(args):
     """STEP-1 = PREPARE: extract Yelp data and derive geo priors."""
     if args.dset != 'yelp':
         raise ValueError('prepare_basic currently supports the Yelp dataset only.')
@@ -130,7 +130,7 @@ def prepare_basic(args) -> dict:
     return prep
 
 
-def process_build(args, prep: dict) -> dict:
+def process_build(args, prep):
     """STEP-2 = PROCESS: segmentation, embeddings, clustering, sentiment."""
     if args.seg_model != 'sat':
         raise ValueError('Only SaT segmentation is implemented for now.')
@@ -162,7 +162,7 @@ def process_build(args, prep: dict) -> dict:
     return proc
 
 
-def segment_with_sat(prep: dict) -> list:
+def segment_with_sat(prep):
     """Segment review text with a SaT-style sentence splitter."""
     segments = []
     info = prep.get('INFO', {})
@@ -191,7 +191,7 @@ def segment_with_sat(prep: dict) -> list:
     return segments
 
 
-def embed_segments(segs: list, model: str) -> dict:
+def embed_segments(segs, model):
     """Create deterministic embeddings for segments."""
     dims = {
         'gte-large': 1024,
@@ -214,7 +214,7 @@ def embed_segments(segs: list, model: str) -> dict:
     return embeddings
 
 
-def cluster(embs: dict, algo: str) -> dict:
+def cluster(embs, algo):
     """Cluster embeddings into aspect buckets."""
     unit_ids = list(embs.keys())
     if not unit_ids:
@@ -232,7 +232,7 @@ def cluster(embs: dict, algo: str) -> dict:
     return aspects
 
 
-def absa_score(segs: list, model: str) -> dict:
+def absa_score(segs, model):
     """Score aspect sentiment with a lightweight lexicon stub."""
     if model != 'pyabsa-restaurants':
         raise ValueError(f'Unsupported absa_model: {model}')
@@ -248,7 +248,7 @@ def absa_score(segs: list, model: str) -> dict:
     return scores
 
 
-def aggregate_item_aspects(segs: list, aspects: dict, sent: dict, topk: int) -> dict:
+def aggregate_item_aspects(segs, aspects, sent, topk):
     """Aggregate per-item aspect sentiment with trimmed means."""
     per_item = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     for seg in segs:
@@ -282,7 +282,7 @@ def aggregate_item_aspects(segs: list, aspects: dict, sent: dict, topk: int) -> 
     return result
 
 
-def pack(segs: list, aspects: dict, sent: dict) -> list:
+def pack(segs, aspects, sent):
     """Merge segment metadata, aspect ids, and sentiment."""
     packed = []
     for seg in segs:
@@ -305,7 +305,7 @@ def pack(segs: list, aspects: dict, sent: dict) -> list:
     return packed
 
 
-def label_aspects(segs: list, aspects: dict) -> dict:
+def label_aspects(segs, aspects):
     """Generate lightweight aspect labels using token frequency."""
     bags = defaultdict(lambda: defaultdict(int))
     for seg in segs:
@@ -322,7 +322,7 @@ def label_aspects(segs: list, aspects: dict) -> dict:
     return labels
 
 
-def haversine_km(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+def haversine_km(lon1, lat1, lon2, lat2):
     """Compute haversine distance in kilometers."""
     r = 6371.0
     lon1_rad = math.radians(lon1)
@@ -336,12 +336,12 @@ def haversine_km(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
     return r * c
 
 
-def coord_median(lons: list, lats: list) -> list:
+def coord_median(lons, lats):
     """Return the coordinate-wise median."""
     return [float(median(lons)), float(median(lats))]
 
 
-def normalize_price(raw) -> int | None:
+def normalize_price(raw):
     """Normalize Yelp price information to integers 1-4 or None."""
     if raw is None:
         return None
@@ -374,7 +374,7 @@ def normalize_price(raw) -> int | None:
     return None
 
 
-def normalize_hours(hours) -> dict:
+def normalize_hours(hours):
     """Normalize Yelp hours into a compact dict."""
     if not hours:
         return {}
@@ -393,7 +393,7 @@ def normalize_hours(hours) -> dict:
     return normalized
 
 
-def parse_categories(raw) -> list:
+def parse_categories(raw):
     """Parse category strings into a list of normalized tokens."""
     if not raw:
         return []
@@ -404,13 +404,13 @@ def parse_categories(raw) -> list:
     return [entry.strip().lower() for entry in entries if entry.strip()]
 
 
-def _ensure_coords(lon, lat) -> list:
+def _ensure_coords(lon, lat):
     if lon is None or lat is None:
         return [None, None]
     return [float(lon), float(lat)]
 
 
-def _kmeans_labels(matrix: np.ndarray) -> np.ndarray:
+def _kmeans_labels(matrix):
     n_samples, dim = matrix.shape
     k = max(1, min(int(math.sqrt(n_samples)) or 1, 32))
     indices = _GLOBAL_RNG.choice(n_samples, size=k, replace=False)
@@ -425,7 +425,7 @@ def _kmeans_labels(matrix: np.ndarray) -> np.ndarray:
     return assign
 
 
-def _density_labels(matrix: np.ndarray) -> np.ndarray:
+def _density_labels(matrix):
     n_samples = matrix.shape[0]
     labels = np.zeros(n_samples, dtype=int)
     radius = np.median(np.linalg.norm(matrix - matrix.mean(axis=0), axis=1))

--- a/systems/ou.py
+++ b/systems/ou.py
@@ -74,10 +74,10 @@ class OUBaseline(BaseSystem):
         device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model = SentenceTransformer(model_name, device=device)
 
-    def _make_prompt(self, doc_text: str) -> str:
+    def _make_prompt(self, doc_text):
         return self.prompt_template.replace("{TEXT}", doc_text)
 
-    def _normalize_unit(self, u: dict) -> dict:
+    def _normalize_unit(self, u):
         aspect = (u.get("aspect") or "").strip()
         sentiment = (u.get("sentiment") or "").strip().lower()
         if sentiment not in {"positive", "negative", "neutral"}:
@@ -122,7 +122,7 @@ class OUBaseline(BaseSystem):
 
     # ---- helper for embedding store (faithful spirit) ----
     @staticmethod
-    def create_query_string(u: dict, include_sentiment: bool = False) -> str:
+    def create_query_string(u, include_sentiment=False):
         """
         Build a string to embed per opinion unit.
         The repo’s flow embeds opinion-unit content for retrieval; two common variants:


### PR DESCRIPTION
## Summary
- strip return annotations and parameter type hints from application entry points, pipeline helpers, and model utilities
- clean up helper, ontology, and system modules to remove function annotations while keeping defaults consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6fa9cc314832ba1e4f96891d50260