### PR TITLE
Add BM25 retrieval baseline

### DIFF
--- a/bin/systems/__init__.py
+++ b/bin/systems/__init__.py
@@ -1,4 +1,5 @@
 from .method import BestSystem, SATBaseline
+from .bm25 import BM25Baseline
 from .ou import OUBaseline
 from .sulm import SULMBaseline
 from .sat import SATBaseline
@@ -10,6 +11,9 @@ def build_system(args, reviews, tests):
     if args.system == 'sat':
         print('[systems] >>> operating Segment Any Text baseline')
         return SATBaseline(args, reviews, tests)
+    if args.system == 'bm25':
+        print('[systems] >>> operating BM25 retrieval baseline')
+        return BM25Baseline(args, reviews)
     if args.system == 'ou':
         print('[systems] >>> operating Opinion Unit baseline')
         return OUBaseline(args, reviews, tests)

--- a/bin/systems/bm25.py
+++ b/bin/systems/bm25.py
@@ -1,0 +1,117 @@
+from collections import defaultdict
+
+from rank_bm25 import BM25Okapi
+
+from .base import BaseSystem
+
+
+class BM25Baseline(BaseSystem):
+    def __init__(self, args, data):
+        super().__init__(args, data)
+        self.cache = {}
+        self.default_city = getattr(self.args, "city", "").strip().lower()
+        if not self.default_city:
+            self.default_city = self._find_default_city()
+        if self.default_city:
+            self._ensure_city(self.default_city)
+
+    def _find_default_city(self):
+        for key, payload in self.data.items():
+            if not isinstance(payload, dict):
+                continue
+            if payload.get("REVIEWS"):
+                return key
+        return ""
+
+    def _ensure_city(self, city):
+        key = (city or "").strip().lower()
+        if not key:
+            return None
+        if key in self.cache:
+            return self.cache[key]
+        payload = self.data.get(key)
+        if not payload:
+            self.cache[key] = None
+            return None
+        docs = self._build_documents(payload)
+        item_ids = list(docs.keys())
+        tokenized = [self._tokenize(docs[iid]) for iid in item_ids]
+        pairs = [(iid, toks) for iid, toks in zip(item_ids, tokenized) if toks]
+        if not pairs:
+            self.cache[key] = None
+            return None
+        item_ids = [iid for iid, _ in pairs]
+        tokenized = [toks for _, toks in pairs]
+        bm25 = BM25Okapi(tokenized)
+        filtered_docs = {iid: docs[iid] for iid in item_ids}
+        model = {
+            "bm25": bm25,
+            "item_ids": item_ids,
+            "documents": filtered_docs,
+            "tokenized": tokenized,
+        }
+        self.cache[key] = model
+        return model
+
+    def _build_documents(self, payload):
+        reviews = payload.get("REVIEWS")
+        if not reviews:
+            reviews = []
+        info = payload.get("INFO")
+        if not info:
+            info = {}
+        grouped = defaultdict(list)
+        for entry in reviews:
+            item_id = entry.get("item_id")
+            text = entry.get("text")
+            if not item_id or not text:
+                continue
+            grouped[item_id].append(text.strip())
+        docs = {}
+        for item_id, texts in grouped.items():
+            parts = []
+            meta = info.get(item_id)
+            if meta:
+                name = meta.get("name")
+                if name:
+                    parts.append(str(name).strip())
+                address = meta.get("address")
+                if address:
+                    parts.append(str(address).strip())
+                categories = meta.get("categories")
+                if isinstance(categories, list) and categories:
+                    parts.append(" ".join(c.strip() for c in categories if c))
+            parts.extend(texts)
+            joined = "\n".join(part for part in parts if part)
+            docs[item_id] = joined
+        return docs
+
+    def _tokenize(self, text):
+        if not text:
+            return []
+        cleaned = []
+        for ch in text:
+            if ch.isalnum():
+                cleaned.append(ch.lower())
+            else:
+                cleaned.append(" ")
+        tokens = [tok for tok in "".join(cleaned).split() if tok]
+        return tokens
+
+    def rank_items(self, request, city=None, top_k=None):
+        model = self._ensure_city(city or self.default_city)
+        if not model or not request:
+            return []
+        tokens = self._tokenize(request)
+        if not tokens:
+            return []
+        scores = model["bm25"].get_scores(tokens)
+        pairs = sorted(zip(model["item_ids"], scores), key=lambda kv: kv[1], reverse=True)
+        if top_k is not None:
+            if top_k <= 0:
+                return []
+            pairs = pairs[:top_k]
+        return [item_id for item_id, _ in pairs]
+
+    def recommend(self, request, city=None, top_k=10):
+        return self.rank_items(request, city=city, top_k=top_k)


### PR DESCRIPTION
## Summary
- add a BM25Baseline system that caches per-city corpora built from reviews and metadata
- integrate the BM25 option into `systems.build_system`

## Testing
- python -m compileall bin/systems/bm25.py

------
https://chatgpt.com/codex/tasks/task_e_68daf947cc08832bb1b84075071793e0