### PR TITLE
Enhance BM25 summaries and base output

### DIFF
--- a/systems/base.py
+++ b/systems/base.py
@@ -157,16 +157,22 @@ class BaseSystem:
                     evidence = entry.get("evidence")
                     if evidence is None:
                         evidence = []
+                    short_excerpt = entry.get("short_excerpt")
+                    full_explanation = entry.get("full_explanation")
                     packaged.append({
                         "item_id": item_id,
                         "model_score": score,
                         "evidence": evidence,
+                        "short_excerpt": short_excerpt,
+                        "full_explanation": full_explanation,
                     })
                 else:
                     packaged.append({
                         "item_id": entry,
                         "model_score": None,
                         "evidence": [],
+                        "short_excerpt": "",
+                        "full_explanation": "",
                     })
             self.result[request_id] = {
                 "request": {
@@ -185,8 +191,7 @@ class BaseSystem:
                 line = f"  {rank}. {candidate['item_id']}"
                 if score is not None:
                     line += f" (score={float(score):.4f})"
-                evidence = candidate.get("evidence")
-                if evidence:
-                    joined = ",".join(str(e) for e in evidence)
-                    line += f" evidence={joined}"
+                short_excerpt = candidate.get("short_excerpt")
+                if short_excerpt:
+                    line += f" — {short_excerpt}"
                 print(line)

--- a/systems/rm25.py
+++ b/systems/rm25.py
@@ -31,6 +31,7 @@ class BM25Baseline(BaseSystem):
             "bm25": bm25,
             "review_ids": prepared.get("review_ids"),
             "review_items": prepared.get("review_items"),
+            "review_texts": prepared.get("review_texts"),
         }
         self.cache[resolved] = model
         return model
@@ -41,6 +42,7 @@ class BM25Baseline(BaseSystem):
             "tokens": [],
             "review_ids": [],
             "review_items": [],
+            "review_texts": [],
         }
         if not isinstance(reviews, list):
             return result
@@ -60,6 +62,7 @@ class BM25Baseline(BaseSystem):
             result["tokens"].append(tokens)
             result["review_ids"].append(review_id)
             result["review_items"].append(item_id)
+            result["review_texts"].append(text)
         return result
 
     def _tokenize(self, text):
@@ -101,9 +104,10 @@ class BM25Baseline(BaseSystem):
                 continue
             item_id = model["review_items"][index]
             review_id = model["review_ids"][index] if index < len(model["review_ids"]) else None
+            review_text = model["review_texts"][index] if index < len(model["review_texts"]) else None
             if not item_id or not review_id:
                 continue
-            aggregated[item_id].append((score, review_id))
+            aggregated[item_id].append((score, review_id, review_text))
         if not aggregated:
             return []
         results = []
@@ -113,21 +117,53 @@ class BM25Baseline(BaseSystem):
             limited = pairs[:m] if m is not None else pairs
             total = 0.0
             evidence = []
-            for score, review_id in limited:
+            review_summaries = []
+            for score, review_id, review_text in limited:
                 total += float(score)
                 evidence.append(review_id)
-            results.append((item_id, total, evidence))
+                normalized_text = self._normalize_text(review_text)
+                if normalized_text:
+                    review_summaries.append(normalized_text)
+            short_excerpt = self._compose_excerpt(review_summaries)
+            full_explanation = self._compose_explanation(review_summaries)
+            results.append((item_id, total, evidence, short_excerpt, full_explanation))
         results.sort(key=lambda row: (-row[1], -len(row[2]), row[0]))
         cutoff = top_k if isinstance(top_k, int) and top_k > 0 else self.top_k
         trimmed = results[:cutoff] if cutoff and cutoff > 0 else results
         formatted = []
-        for item_id, score, evidence in trimmed:
+        for item_id, score, evidence, short_excerpt, full_explanation in trimmed:
             formatted.append({
                 "item_id": item_id,
                 "model_score": float(score),
                 "evidence": list(evidence),
+                "short_excerpt": short_excerpt,
+                "full_explanation": full_explanation,
             })
         return formatted
 
     def recommend(self, request, city=None, top_k=None):
         return self.rank_items(request, city=city, top_k=top_k)
+
+    def _normalize_text(self, text):
+        if not text:
+            return ""
+        collapsed = " ".join(str(text).split())
+        return collapsed.strip()
+
+    def _compose_excerpt(self, summaries):
+        if not summaries:
+            return ""
+        combined = " ".join(summaries)
+        max_len = 160
+        if len(combined) <= max_len:
+            return combined
+        trimmed = combined[:max_len].rstrip()
+        return f"{trimmed}…"
+
+    def _compose_explanation(self, summaries):
+        if not summaries:
+            return ""
+        parts = []
+        for idx, summary in enumerate(summaries, 1):
+            parts.append(f"{idx}) {summary}")
+        return " ".join(parts)


### PR DESCRIPTION
## Summary
- capture review texts in the BM25 baseline and derive short excerpts plus full explanations alongside evidence
- surface the new summaries through the base system results and display short excerpts during evaluation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0445bc18832b81a7c4a12b41906e