### PR TITLE
Add spelling correction and review segmentation to BaseSystem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,6 @@ dependencies = [
     "openai>=1.97.0",
     "pandas>=2.3.1",
     "sentence-transformers>=5.0.0",
+    "symspellpy>=6.7.7",
+    "wtpsplit>=1.0.4",
 ]


### PR DESCRIPTION
## Summary
- integrate a SymSpell-based spell corrector so normalized requests automatically clean typos
- build reusable Segment Anything Text segments per review with identifiers that preserve review ids
- declare symspellpy and wtpsplit as project dependencies

## Testing
- python -m compileall systems/base.py

------
https://chatgpt.com/codex/tasks/task_e_68dd89311894832b80233186db1af0ad