### PR TITLE
Refactor shared text helpers into BaseSystem

### DIFF
--- a/systems/base.py
+++ b/systems/base.py
@@ -270,6 +270,30 @@ class BaseSystem:
         tokens = "".join(buffer).split()
         return [tok for tok in tokens if tok]
 
+    def _normalize_text(self, text):
+        if not text:
+            return ""
+        collapsed = " ".join(str(text).split())
+        return collapsed.strip()
+
+    def _compose_excerpt(self, summaries):
+        if not summaries:
+            return ""
+        combined = " ".join(summaries)
+        max_len = 160
+        if len(combined) <= max_len:
+            return combined
+        trimmed = combined[:max_len].rstrip()
+        return f"{trimmed}…"
+
+    def _compose_explanation(self, summaries):
+        if not summaries:
+            return ""
+        parts = []
+        for idx, summary in enumerate(summaries, 1):
+            parts.append(f"{idx}) {summary}")
+        return " ".join(parts)
+
     def _build_symspell(self, reviews):
         if not reviews:
             return None

--- a/systems/dense.py
+++ b/systems/dense.py
@@ -141,27 +141,3 @@ class DenseRetrieverBaseline(BaseSystem):
                 "full_explanation": full_explanation,
             })
         return formatted
-
-    def _normalize_text(self, text):
-        if not text:
-            return ""
-        collapsed = " ".join(str(text).split())
-        return collapsed.strip()
-
-    def _compose_excerpt(self, summaries):
-        if not summaries:
-            return ""
-        combined = " ".join(summaries)
-        max_len = 160
-        if len(combined) <= max_len:
-            return combined
-        trimmed = combined[:max_len].rstrip()
-        return f"{trimmed}…"
-
-    def _compose_explanation(self, summaries):
-        if not summaries:
-            return ""
-        parts = []
-        for idx, summary in enumerate(summaries, 1):
-            parts.append(f"{idx}) {summary}")
-        return " ".join(parts)

--- a/systems/method.py
+++ b/systems/method.py
@@ -595,27 +595,3 @@ class HyperbolicSegmentSystem(BaseSystem):
         }
         self.city_indexes[key] = index
         return index
-
-    def _normalize_text(self, text):
-        if not text:
-            return ""
-        collapsed = " ".join(str(text).split())
-        return collapsed.strip()
-
-    def _compose_excerpt(self, summaries):
-        if not summaries:
-            return ""
-        combined = " ".join(summaries)
-        max_len = 160
-        if len(combined) <= max_len:
-            return combined
-        trimmed = combined[:max_len].rstrip()
-        return f"{trimmed}…"
-
-    def _compose_explanation(self, summaries):
-        if not summaries:
-            return ""
-        parts = []
-        for idx, summary in enumerate(summaries, 1):
-            parts.append(f"{idx}) {summary}")
-        return " ".join(parts)

--- a/systems/sparse.py
+++ b/systems/sparse.py
@@ -144,27 +144,3 @@ class BM25Baseline(BaseSystem):
 
     def recommend(self, request, city=None, top_k=None):
         return self.rank_items(request, city=city, top_k=top_k)
-
-    def _normalize_text(self, text):
-        if not text:
-            return ""
-        collapsed = " ".join(str(text).split())
-        return collapsed.strip()
-
-    def _compose_excerpt(self, summaries):
-        if not summaries:
-            return ""
-        combined = " ".join(summaries)
-        max_len = 160
-        if len(combined) <= max_len:
-            return combined
-        trimmed = combined[:max_len].rstrip()
-        return f"{trimmed}…"
-
-    def _compose_explanation(self, summaries):
-        if not summaries:
-            return ""
-        parts = []
-        for idx, summary in enumerate(summaries, 1):
-            parts.append(f"{idx}) {summary}")
-        return " ".join(parts)


### PR DESCRIPTION
## Summary
- move the text normalization, excerpt, and explanation helpers into `BaseSystem` for consistent reuse
- remove the duplicated helper implementations from the sparse, dense, and method systems so they rely on the shared versions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dedce659ac832bab0ba7e45d3afae6