### PR TITLE
Refactor Yelp data to pooled schema

### DIFF
--- a/data/adapters.py
+++ b/data/adapters.py
@@ -1,0 +1,39 @@
+def city_view(global_data, city):
+    reviews = []
+    users = {}
+    items = {}
+    info = {}
+
+    pooled_items = global_data.get("items") or {}
+    pooled_reviews = global_data.get("reviews") or {}
+    pooled_users = global_data.get("users") or {}
+
+    for item_id, meta in pooled_items.items():
+        if meta.get("city") != city:
+            continue
+        review_ids = list(meta.get("review_ids") or [])
+        items[item_id] = review_ids
+        info[item_id] = {key: value for key, value in meta.items() if key != "review_ids"}
+
+    valid_rids = set()
+    for rids in items.values():
+        for rid in rids:
+            valid_rids.add(rid)
+
+    for rid in valid_rids:
+        record = pooled_reviews.get(rid)
+        if not record:
+            continue
+        entry = {"review_id": rid}
+        entry.update(record)
+        reviews.append(entry)
+
+    for uid, meta in pooled_users.items():
+        linked = []
+        for rid in meta.get("review_ids") or []:
+            if rid in valid_rids:
+                linked.append(rid)
+        if linked:
+            users[uid] = linked
+
+    return {"USERS": users, "ITEMS": items, "REVIEWS": reviews, "INFO": info}


### PR DESCRIPTION
## Summary
- return a pooled Yelp payload keyed by ids and attach a schema flag
- provide a city_view adapter so existing city-based systems continue to work
- update Yelp processing and BaseSystem helpers to consume the pooled structure

## Testing
- python -m compileall data systems

------
https://chatgpt.com/codex/tasks/task_e_68e1607e1648832b86df71e7f43d19dc