### PR TITLE
Rename llm module to api

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,4 +1,4 @@
-# llm.py
+# api.py
 import io
 import re
 import time

--- a/data/synthesize_requests.py
+++ b/data/synthesize_requests.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import numpy as np
 
 from utils import loadp, writef
-from llm import run_llm_batch
+from api import run_llm_batch
 
 KEYWORD_TASK = "segment_to_keyword"
 REQUEST_TASK = "keyword_bundle_to_request"

--- a/systems/method.py
+++ b/systems/method.py
@@ -12,7 +12,7 @@ from sentence_transformers import SentenceTransformer
 from transformers.utils import is_flash_attn_2_available
 
 from .base import BaseSystem
-from llm import run_llm_batch
+from api import run_llm_batch
 
 
 # =========================

--- a/systems/ou.py
+++ b/systems/ou.py
@@ -5,7 +5,7 @@ import numpy as np
 from sentence_transformers import SentenceTransformer
 
 from .base import BaseSystem
-from llm import run_llm_batch, safe_json_parse
+from api import run_llm_batch, safe_json_parse
 
 from utils import load_or_build, dumpj
 

--- a/systems/react.py
+++ b/systems/react.py
@@ -1,7 +1,7 @@
 from .base import BaseSystem
 from .sparse import BM25Baseline
 from .dense import DenseRetrieverBaseline
-from llm import query_llm, safe_json_parse
+from api import query_llm, safe_json_parse
 
 KEYWORD_PROMPT = """You are an expert retrieval strategist helping with restaurant review search.\nUser request: {request_text}\nPrevious keyword attempts: {previous_keywords}\nRecent retrieval takeaway: {retrieval_summary}\nReflection from the last step: {previous_reasoning}\nGuidance to follow now: {previous_summary}\nCompose fresh, focused search keywords that build on what has been learned while addressing the new guidance.\nReturn strict JSON with keys: keywords (array of 1-4 short keywords or phrases) and reasoning (one sentence describing why they were chosen)."""
 


### PR DESCRIPTION
## Summary
- rename the llm helper module to api.py
- update all imports to reference the new module name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e57ba9f200832b8658d30c2fed9fd1