### PR TITLE
Refactor base system orchestration

### DIFF
--- a/networks/encoder.py
+++ b/networks/encoder.py
@@ -1,163 +1,250 @@
 import os
+import logging
+from pathlib import Path
+from collections import defaultdict
+
+import faiss
 import numpy as np
 import torch
 import torch.nn.functional as F
-from collections import defaultdict
 from tqdm import tqdm
-
 from huggingface_hub import hf_hub_download
 from transformers import AutoModel, AutoTokenizer, BitsAndBytesConfig
 
-class Encoder:
-    def _prepare_model(self):
-        # Drop-in switch to NovaSearch/stella_en_1.5B_v5 with 1024-d vectors (8-bit).
-        # Uses the Transformers path (fast + quantized) and the official projection layer from 2_Dense_1024.
-        
-        self._model_name = "NovaSearch/stella_en_1.5B_v5"
-        self._query_prompt_s2p = "Instruct: Given a web search query, retrieve relevant passages that answer the query.\nQuery: "
-        self._query_prompt_s2s = "Instruct: Retrieve semantically similar text.\nQuery: "
-        self._vector_dim = 1024  # default dimension recommended by the authors
+from utils import dumpp, loadp
 
-        # 8-bit weights + BF16 activations for speed/VRAM
-        bnb_cfg = BitsAndBytesConfig(load_in_8bit=True)
-        self.tokenizer = AutoTokenizer.from_pretrained(self._model_name, trust_remote_code=True)
-        self.model = AutoModel.from_pretrained(
-            self._model_name,
-            trust_remote_code=True,
-            quantization_config=bnb_cfg,
-            device_map="cuda",
-            torch_dtype=torch.float16,
-        ).eval()
 
-        # Load the official projection layer weights for 1024-d from repo folder 2_Dense_1024
-        vector_linear_directory = f"2_Dense_{self._vector_dim}"
-        ckpt_path = hf_hub_download(repo_id=self._model_name, filename=os.path.join(vector_linear_directory, "pytorch_model.bin"))
-        state = torch.load(ckpt_path, map_location="cpu")
-        # The file uses keys like 'linear.weight' / 'linear.bias' — strip the 'linear.' prefix.
-        state = {k.replace("linear.", ""): v for k, v in state.items()}
+_ENCODER_STATE = {}
 
-        # Build the projection layer and move to CUDA if available
-        self._proj = torch.nn.Linear(in_features=self.model.config.hidden_size, out_features=self._vector_dim)
-        self._proj.load_state_dict(state, strict=True)
-        
-        model_device = next(self.model.parameters()).device
-        self._proj = self._proj.to(device=model_device, dtype=torch.float16).eval()
 
-    def _tokenize_with_progress(self, texts, max_length=160, chunk_size=1024):
-        """
-        Tokenize with a progress bar. Returns a dict with 'input_ids', 'attention_mask', 'length', ...
-        """
-        all_encodings = {"input_ids": [], "attention_mask": [], "length": []}
+def _prepare_model():
+    global _ENCODER_STATE
+    if _ENCODER_STATE:
+        return _ENCODER_STATE
+    model_name = "NovaSearch/stella_en_1.5B_v5"
+    query_prompt_s2p = "Instruct: Given a web search query, retrieve relevant passages that answer the query.\nQuery: "
+    query_prompt_s2s = "Instruct: Retrieve semantically similar text.\nQuery: "
+    vector_dim = 1024
+    bnb_cfg = BitsAndBytesConfig(load_in_8bit=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModel.from_pretrained(
+        model_name,
+        trust_remote_code=True,
+        quantization_config=bnb_cfg,
+        device_map="cuda",
+        torch_dtype=torch.float16,
+    ).eval()
+    vector_linear_directory = f"2_Dense_{vector_dim}"
+    ckpt_path = hf_hub_download(repo_id=model_name, filename=os.path.join(vector_linear_directory, "pytorch_model.bin"))
+    state = torch.load(ckpt_path, map_location="cpu")
+    cleaned = {k.replace("linear.", ""): v for k, v in state.items()}
+    proj = torch.nn.Linear(in_features=model.config.hidden_size, out_features=vector_dim)
+    proj.load_state_dict(cleaned, strict=True)
+    proj = proj.to(device=next(model.parameters()).device, dtype=torch.float16).eval()
+    _ENCODER_STATE = {
+        "model_name": model_name,
+        "tokenizer": tokenizer,
+        "model": model,
+        "proj": proj,
+        "vector_dim": vector_dim,
+        "query_prompt_s2p": query_prompt_s2p,
+        "query_prompt_s2s": query_prompt_s2s,
+    }
+    return _ENCODER_STATE
 
-        for i in tqdm(range(0, len(texts), chunk_size), ncols=88, desc=f"[{self._model_name}] Tokenizing", leave=False):
-            chunk = texts[i:i + chunk_size]
-            enc = self.tokenizer(
-                chunk,
-                padding=False,
-                truncation=True,
-                max_length=max_length,
-                return_length=True,
-                return_tensors=None,
-            )
-            all_encodings["input_ids"].extend(enc["input_ids"])
-            all_encodings["attention_mask"].extend(enc["attention_mask"])
-            all_encodings["length"].extend(enc["length"])
 
-        return all_encodings
+def _tokenize_with_progress(texts, max_length=160, chunk_size=1024):
+    state = _prepare_model()
+    tokenizer = state["tokenizer"]
+    result = {"input_ids": [], "attention_mask": [], "length": []}
+    total = len(texts)
+    for i in tqdm(range(0, total, chunk_size), ncols=88, desc=f"[{state['model_name']}] Tokenizing", leave=False):
+        chunk = texts[i:i + chunk_size]
+        enc = tokenizer(
+            chunk,
+            padding=False,
+            truncation=True,
+            max_length=max_length,
+            return_length=True,
+            return_tensors=None,
+        )
+        result["input_ids"].extend(enc["input_ids"])
+        result["attention_mask"].extend(enc["attention_mask"])
+        result["length"].extend(enc["length"])
+    return result
 
-    def _model_encode(self, texts, isquery=False, batch_size=512, max_length=256, normalize=True, return_numpy=True, query_task="s2s"):
-        """
-        Encode with Stella v5 (8-bit) and return 1024-d embeddings.
-        mode: 'passage' (no prompt) or 'query' (adds prompt). For queries, choose task via query_task:
-              - 's2p' (sentence->passage retrieval, recommended for RAG)
-              - 's2s' (sentence->sentence similarity)
-        """
-        if isquery:
-            if query_task == "s2p":
-                prefix = self._query_prompt_s2p
-            elif query_task == "s2s":
-                prefix = self._query_prompt_s2s
-            else:
-                raise ValueError("query_task must be 's2p' or 's2s'")
+
+def _model_encode(texts, isquery=False, batch_size=512, max_length=256, normalize=True, query_task="s2s", return_numpy=True):
+    state = _prepare_model()
+    model_name = state["model_name"]
+    tokenizer = state["tokenizer"]
+    model = state["model"]
+    proj = state["proj"]
+    if isquery:
+        if query_task == "s2p":
+            prefix = state["query_prompt_s2p"]
+        elif query_task == "s2s":
+            prefix = state["query_prompt_s2s"]
         else:
-            prefix = ""
+            raise ValueError("query_task must be 's2p' or 's2s'")
+    else:
+        prefix = ""
+    single = False
+    if type(texts) is str:
+        single = True
+        texts = [texts]
+    if prefix:
+        texts = [prefix + t for t in texts]
+    device = next(model.parameters()).device
+    len_enc = _tokenize_with_progress(texts, max_length=max_length, chunk_size=1024)
+    lengths = len_enc["length"]
+    idxs = np.argsort(lengths)
+    bucket_bins = (64, 96, 128, 160)
 
-        single = isinstance(texts, str)
-        if single:
-            texts = [texts]
-        if prefix:
-            texts = [prefix + t for t in texts]
+    def which_bin(L):
+        for b in bucket_bins:
+            if L <= b:
+                return b
+        return bucket_bins[-1]
 
-        device = next(self.model.parameters()).device
+    buckets = defaultdict(list)
+    for i in tqdm(idxs, ncols=88, desc=f"[{model_name}] sorting buckets...", leave=False):
+        buckets[which_bin(lengths[i])].append(i)
+    vecs = [None] * len(texts)
+    with torch.inference_mode():
+        for _, inds in tqdm(buckets.items(), ncols=88, desc=f"[{model_name}] encode", leave=False):
+            for s in range(0, len(inds), batch_size):
+                sub = inds[s:s + batch_size]
+                sub_texts = [texts[i] for i in sub]
+                batch = tokenizer(
+                    sub_texts,
+                    padding="longest",
+                    truncation=True,
+                    max_length=max_length,
+                    return_tensors="pt",
+                )
+                for k, v in batch.items():
+                    batch[k] = v.pin_memory()
+                    batch[k] = batch[k].to(device, non_blocking=True)
+                last_hidden = model(**batch)[0]
+                mask = batch["attention_mask"].unsqueeze(-1).to(last_hidden.dtype)
+                sent_vec = (last_hidden * mask).sum(1) / mask.sum(1).clamp_min(1e-6)
+                sent_vec = sent_vec.to(proj.weight.dtype)
+                vec = proj(sent_vec)
+                if normalize:
+                    vec = F.normalize(vec, p=2, dim=1)
+                if return_numpy:
+                    vec = vec.detach().cpu().numpy()
+                for j, idx in enumerate(sub):
+                    vecs[idx] = vec[j] if return_numpy else vec[j:j + 1]
+    if single:
+        return vecs[0]
+    if return_numpy:
+        return np.stack(vecs, axis=0)
+    return torch.cat(vecs, dim=0)
 
-        # ---- quick length pass (no padding) to build buckets ----
-        # print(f'[{self._model_name}] building buckets...')
-        # len_enc = self.tokenizer(
-        #     texts,
-        #     padding=False,
-        #     truncation=True,
-        #     max_length=max_length,
-        #     return_length=True,
-        # )
-        # lengths = len_enc["length"]
-        len_enc = self._tokenize_with_progress(texts, max_length=max_length, chunk_size=1024)
-        lengths = len_enc["length"]
-        idxs = np.argsort(lengths)  # shortest -> longest
 
-        bucket_bins=(64, 96, 128, 160)
-        
-        def which_bin(L):
-            for b in bucket_bins:
-                if L <= b:
-                    return b
-            return bucket_bins[-1]
+def build_segment_embeddings(segments, output_path, flush_size=10240):
+    output_path = Path(output_path)
+    partial_path = Path(str(output_path) + ".partial")
+    partial_path.parent.mkdir(parents=True, exist_ok=True)
+    entries = []
+    seen = set()
+    if partial_path.exists():
+        logging.info(f"[encoder] resuming embeddings from {partial_path}")
+        cached = loadp(partial_path)
+        stored = cached.get("entries") if cached else None
+        if stored:
+            entries = stored
+            for entry in entries:
+                sid = entry.get("segment_id")
+                if sid:
+                    seen.add(sid)
+    def flush(records, texts):
+        if not texts:
+            return
+        embeds = _model_encode(texts)
+        for idx, vector in enumerate(embeds):
+            item = records[idx]
+            item["embedding"] = vector.tolist()
+            entries.append(item)
+            sid = item.get("segment_id")
+            if sid:
+                seen.add(sid)
+        dumpp(partial_path, {"entries": entries})
+    batch_records = []
+    batch_texts = []
+    for record in tqdm(segments, ncols=88, desc="[encoder] embed segments"):
+        text = record.get("text")
+        if not text:
+            continue
+        sid = record.get("segment_id")
+        if sid and sid in seen:
+            continue
+        info = {
+            "segment_id": sid,
+            "review_id": record.get("review_id"),
+            "item_id": record.get("item_id"),
+            "text": text,
+        }
+        batch_records.append(info)
+        batch_texts.append(text)
+        if len(batch_texts) >= flush_size:
+            flush(batch_records, batch_texts)
+            batch_records = []
+            batch_texts = []
+    if batch_texts:
+        flush(batch_records, batch_texts)
+    partial_path.unlink(missing_ok=True)
+    if not entries:
+        return {"entries": [], "index": None, "matrix": None, "dimension": None}
+    entry_map = {}
+    for entry in entries:
+        sid = entry.get("segment_id")
+        if sid and sid not in entry_map:
+            entry_map[sid] = entry
+    ordered = []
+    used = set()
+    for record in segments:
+        sid = record.get("segment_id")
+        if not sid or sid in used:
+            continue
+        entry = entry_map.get(sid)
+        if entry:
+            ordered.append(entry)
+            used.add(sid)
+    entries = ordered
+    if not entries:
+        return {"entries": [], "index": None, "matrix": None, "dimension": None}
+    matrix = np.asarray([entry.get("embedding") for entry in entries], dtype="float32")
+    dim = matrix.shape[1]
+    index = faiss.IndexFlatIP(dim)
+    index.add(matrix)
+    serialized = faiss.serialize_index(index)
+    return {
+        "entries": entries,
+        "index": serialized,
+        "matrix": matrix,
+        "dimension": dim,
+    }
 
-        buckets = defaultdict(list)
-        for i in tqdm(idxs, ncols=88, desc=f'[{self._model_name}] sorting buckets...', leave=False):
-            buckets[which_bin(lengths[i])].append(i)
-        # print(f'[{self._model_name}] buckets built')
 
-        # ---- encode per bucket ----
-        vecs = [None] * len(texts)
-        with torch.inference_mode():
-            for _, inds in tqdm(buckets.items(), ncols=88, desc=f'[{self._model_name}] encode', leave=False):
-                for s in range(0, len(inds), batch_size):
-                    sub = inds[s:s + batch_size]
-                    sub_texts = [texts[i] for i in sub]
-
-                    # Tokenize to pinned CPU memory
-                    batch = self.tokenizer(
-                        sub_texts,
-                        padding="longest",
-                        truncation=True,
-                        max_length=max_length,
-                        return_tensors="pt",
-                    )
-                    # Pin & non_blocking copy to GPU
-                    for k, v in batch.items():
-                        batch[k] = v.pin_memory()
-                        batch[k] = batch[k].to(device, non_blocking=True)
-
-                    # Forward + mean pool
-                    last_hidden = self.model(**batch)[0]                       # [B, L, H]
-                    mask = batch["attention_mask"].unsqueeze(-1).to(last_hidden.dtype)
-                    sent_vec = (last_hidden * mask).sum(1) / mask.sum(1).clamp_min(1e-6)
-
-                    # Match projection dtype (fp16/bf16) and project to 1024-d
-                    sent_vec = sent_vec.to(self._proj.weight.dtype)
-                    vec = self._proj(sent_vec)
-
-                    if normalize:
-                        vec = F.normalize(vec, p=2, dim=1)
-
-                    if return_numpy:
-                        vec = vec.detach().cpu().numpy()
-
-                    for j, i in enumerate(sub):
-                        vecs[i] = vec[j] if return_numpy else vec[j:j+1]
-
-        if single:
-            return vecs[0]
-        if return_numpy:
-            return np.stack(vecs, axis=0)
-        return torch.cat(vecs, dim=0)
+def apply_segment_embeddings(payload):
+    data = payload or {}
+    entries = data.get("entries") or []
+    matrix = data.get("matrix")
+    if matrix is None and entries:
+        vectors = []
+        for entry in entries:
+            vector = entry.get("embedding")
+            if vector is None:
+                continue
+            vectors.append(vector)
+        if vectors:
+            matrix = np.asarray(vectors, dtype="float32")
+    index_bytes = data.get("index")
+    index = faiss.deserialize_index(index_bytes) if index_bytes else None
+    dimension = data.get("dimension")
+    if matrix is not None and dimension is None:
+        dimension = matrix.shape[1]
+    return matrix, index, entries, dimension

--- a/networks/index.py
+++ b/networks/index.py
@@ -1,0 +1,22 @@
+import faiss
+import numpy as np
+
+
+def build_index(vectors, ids, cfg):
+    dim = vectors.shape[1]
+    index_type = cfg.get("type")
+    if index_type == "HNSW":
+        index = faiss.IndexHNSWFlat(dim, 32, faiss.METRIC_INNER_PRODUCT)
+        index.add_with_ids(vectors.astype("float32"), np.array(ids, dtype="int64"))
+        return index
+    if index_type == "IVF-PQ":
+        quantizer = faiss.IndexHNSWFlat(dim, 32, faiss.METRIC_INNER_PRODUCT)
+        index = faiss.IndexIVFPQ(quantizer, dim, cfg["ivf_nlist"], cfg["pq_m"], 8, faiss.METRIC_INNER_PRODUCT)
+        index.train(vectors.astype("float32"))
+        index.add_with_ids(vectors.astype("float32"), np.array(ids, dtype="int64"))
+        return index
+    raise ValueError("index type must be 'HNSW' or 'IVF-PQ'")
+
+
+def search_index(index, queries, k=10):
+    return index.search(queries.astype("float32"), k)

--- a/systems/base.py
+++ b/systems/base.py
@@ -1,57 +1,48 @@
-import torch
-import numpy as np
-import faiss
-from tqdm import tqdm
 import logging
 
-from pathlib import Path
-
 from utils import load_or_build, dumpp, loadp
-
-from networks.encoder import Encoder
+from networks.encoder import build_segment_embeddings, apply_segment_embeddings
 from networks.symspell import build_symspell, correct_spelling
 from networks.segmenter import segment_reviews, apply_segment_data
-import multiprocessing as mp
-mp.set_start_method("spawn", force=True)
 
-class BaseSystem(Encoder):
+
+class BaseSystem:
     def __init__(self, args, data):
-        super().__init__()
         self.args = args
         self.data = data
-        self.reviews = data['reviews']
-        self._prepare_model()
+        self.reviews = data["reviews"]
         self.segment_batch_size = 32
         self.flush_size = 10240
 
-        self.result = {}
         symspell_path = args.clean_dir / f"symspell_{args.dset}.pkl"
         self.symspell = load_or_build(symspell_path, dumpp, loadp, build_symspell, self.reviews)
+
         segment_path = args.clean_dir / f"segments_{args.dset}.pkl"
         segment_payload = load_or_build(segment_path, dumpp, loadp, segment_reviews, self.reviews, self.segment_batch_size)
-        segments, segment_lookup, review_segments, item_segments = apply_segment_data(segment_payload)
+        segments, lookup, review_segments, item_segments = apply_segment_data(segment_payload)
         self.segments = segments
-        self.segment_lookup = segment_lookup
+        self.segment_lookup = lookup
         self.review_segments = review_segments
         self.item_segments = item_segments
-        
+
         embedding_path = args.clean_dir / f"segment_embeddings_{args.dset}.pkl"
         self.embedding_path = embedding_path
-        self.embedding_partial_path = Path(str(embedding_path) + ".partial")
         if embedding_path.exists():
             logging.info(f"[base] loading embeddings from {embedding_path}")
             embedding_payload = loadp(embedding_path)
         else:
             logging.info(f"[base] building embeddings → {embedding_path}")
-            embedding_payload = self._build_segment_embeddings(self.segments)
+            embedding_payload = build_segment_embeddings(
+                self.segments,
+                embedding_path,
+                flush_size=self.flush_size,
+            )
             dumpp(embedding_path, embedding_payload)
-        self._apply_segment_embeddings(embedding_payload)
-
-        print(self.segment_embedding_matrix.shape)
-        print(len(self.segments))
-        print(len(self.reviews))
-        print(self.data.keys())
-        print([len(x) for x in self.data.values()])
+        matrix, index, entries, dim = apply_segment_embeddings(embedding_payload)
+        self.segment_embedding_matrix = matrix
+        self.segment_faiss_index = index
+        self.segment_embedding_entries = entries
+        self.segment_embedding_dim = dim
 
     def spellfix(self, text):
         return correct_spelling(self.symspell, text)
@@ -61,117 +52,3 @@ class BaseSystem(Encoder):
 
     def get_segment(self, segment_id):
         return self.segment_lookup.get(segment_id)
-
-    # % --- embedding ---
-
-    def _build_segment_embeddings(self, segments):
-        partial_path = self.embedding_partial_path
-        partial_path.parent.mkdir(parents=True, exist_ok=True)
-        entries = []
-        seen = set()
-        if partial_path.exists():
-            logging.info(f"[base] resuming embeddings from {partial_path}")
-            cached = loadp(partial_path)
-            if isinstance(cached, dict):
-                stored = cached.get("entries")
-                if isinstance(stored, list):
-                    entries = stored
-                    for entry in entries:
-                        sid = entry.get("segment_id")
-                        if sid:
-                            seen.add(sid)
-
-        def flush(records, texts):
-            if not texts:
-                return
-            # logging.info(f"[base] encoding {len(texts)} segments")
-            embeds = self._model_encode(texts)
-            for idx, vector in enumerate(embeds):
-                item = records[idx]
-                item["embedding"] = vector.tolist()
-                entries.append(item)
-                sid = item.get("segment_id")
-                if sid:
-                    seen.add(sid)
-            dumpp(partial_path, {"entries": entries})
-
-        batch_records = []
-        batch_texts = []
-        for record in tqdm(segments, ncols=88, desc='[base] embed segments'):
-            text = record.get("text")
-            if not text:
-                continue
-            sid = record.get("segment_id")
-            if sid and sid in seen:
-                continue
-            info = {
-                "segment_id": sid,
-                "review_id": record.get("review_id"),
-                "item_id": record.get("item_id"),
-                "text": text,
-            }
-            batch_records.append(info)
-            batch_texts.append(text)
-            if len(batch_texts) >= self.flush_size:
-                flush(batch_records, batch_texts)
-                batch_records = []
-                batch_texts = []
-        if batch_texts:
-            flush(batch_records, batch_texts)
-
-        partial_path.unlink(missing_ok=True)
-
-        if not entries:
-            return {"entries": [], "index": None, "matrix": None, "dimension": None}
-
-        entry_map = {}
-        for entry in entries:
-            sid = entry.get("segment_id")
-            if sid and sid not in entry_map:
-                entry_map[sid] = entry
-        ordered = []
-        used = set()
-        for record in segments:
-            sid = record.get("segment_id")
-            if not sid or sid in used:
-                continue
-            entry = entry_map.get(sid)
-            if entry:
-                ordered.append(entry)
-                used.add(sid)
-        entries = ordered
-        if not entries:
-            return {"entries": [], "index": None, "matrix": None, "dimension": None}
-
-        matrix = np.asarray([entry.get("embedding") for entry in entries], dtype="float32")
-        dim = matrix.shape[1]
-        index = faiss.IndexFlatIP(dim)
-        index.add(matrix)
-        serialized = faiss.serialize_index(index)
-        return {
-            "entries": entries,
-            "index": serialized,
-            "matrix": matrix,
-            "dimension": dim,
-        }
-
-    def _apply_segment_embeddings(self, payload):
-        data = payload or {}
-        entries = data.get("entries")
-        if entries is None:
-            entries = []
-        self.segment_embedding_entries = entries
-        matrix = data.get("matrix")
-        if matrix is None and entries:
-            vectors = []
-            for entry in entries:
-                vector = entry.get("embedding")
-                if vector is None:
-                    continue
-                vectors.append(vector)
-            if vectors:
-                matrix = np.array(vectors, dtype="float32")
-        self.segment_embedding_matrix = matrix
-        self.segment_embedding_dim = data.get("dimension")
-        index_bytes = data.get("index")
-        self.segment_faiss_index = faiss.deserialize_index( index_bytes)


### PR DESCRIPTION
## Summary
- simplify `BaseSystem` so it orchestrates spell correction, segmentation, and embedding loading via reusable helpers
- expose the encoder model setup and embedding builder as module-level utilities that retain resumable batching semantics
- add a FAISS index helper to construct HNSW or IVF-PQ indexes with explicit id management

## Testing
- python -m compileall systems/base.py networks/encoder.py networks/index.py

------
https://chatgpt.com/codex/tasks/task_e_68e59106594c832b85baeff68a946797